### PR TITLE
feat: turn off screen on Android while listening for proximity events

### DIFF
--- a/android/src/main/kotlin/dev/jeremyko/proximity_sensor/ProximitySensorPlugin.kt
+++ b/android/src/main/kotlin/dev/jeremyko/proximity_sensor/ProximitySensorPlugin.kt
@@ -1,7 +1,6 @@
 
 package dev.jeremyko.proximity_sensor
 
-import androidx.annotation.NonNull
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.plugin.common.EventChannel
 
@@ -10,10 +9,9 @@ class ProximitySensorPlugin: FlutterPlugin  {
   private lateinit var channel : EventChannel
   private lateinit var streamHandler : ProximityStreamHandler
 
-  override fun onAttachedToEngine(@NonNull flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
+  override fun onAttachedToEngine(flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
     channel = EventChannel(flutterPluginBinding.binaryMessenger, "proximity_sensor")
-    streamHandler = ProximityStreamHandler( flutterPluginBinding.applicationContext,
-                                            flutterPluginBinding.binaryMessenger)
+    streamHandler = ProximityStreamHandler( flutterPluginBinding.applicationContext)
     channel.setStreamHandler(streamHandler)
   }
 

--- a/android/src/main/kotlin/dev/jeremyko/proximity_sensor/ProximityStreamHandler.kt
+++ b/android/src/main/kotlin/dev/jeremyko/proximity_sensor/ProximityStreamHandler.kt
@@ -1,25 +1,29 @@
 package dev.jeremyko.proximity_sensor
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.hardware.Sensor
 import android.hardware.SensorEvent
 import android.hardware.SensorEventListener
 import android.hardware.SensorManager
-import io.flutter.plugin.common.BinaryMessenger
+import android.os.Build
+import android.os.PowerManager
 import io.flutter.plugin.common.EventChannel
-import java.io.IOException
 import java.lang.UnsupportedOperationException
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 class ProximityStreamHandler(
         private val applicationContext: Context,
-        private val messenger: BinaryMessenger
 ): EventChannel.StreamHandler, SensorEventListener {
 
     private var eventSink: EventChannel.EventSink? = null
     private lateinit var sensorManager: SensorManager
     private var proximitySensor: Sensor? = null
 
+    private lateinit var powerManager: PowerManager
+    private lateinit var wakeLock: PowerManager.WakeLock
+
+    @SuppressLint("WakelockTimeout")
     override fun onListen(arguments: Any?, events: EventChannel.EventSink?) {
         eventSink = events
         sensorManager =  applicationContext.getSystemService(Context.SENSOR_SERVICE) as SensorManager
@@ -27,10 +31,22 @@ class ProximityStreamHandler(
             throw UnsupportedOperationException("proximity sensor unavailable")
 
         sensorManager.registerListener(this, proximitySensor, SensorManager.SENSOR_DELAY_NORMAL)
+        powerManager = applicationContext.getSystemService(Context.POWER_SERVICE) as
+            PowerManager
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            wakeLock = powerManager.newWakeLock(PowerManager.PROXIMITY_SCREEN_OFF_WAKE_LOCK, "dev.jeremyko.proximity_sensor:lock")
+            if (!wakeLock.isHeld) {
+                wakeLock.acquire()
+            }
+        }
     }
 
     override fun onCancel(arguments: Any?) {
         sensorManager.unregisterListener(this, proximitySensor)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            wakeLock.release()
+        }
     }
 
     override fun onSensorChanged(event: SensorEvent?) {


### PR DESCRIPTION
Similar to iOS, switch off screen if the plugin is active and the phone is near the ear.

Should fix #1 and #4