### PR TITLE
add namespace for AGP 8

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,7 +26,9 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 30
-
+    if (project.android.hasProperty('namespace')) {
+        namespace 'dev.jeremyko.proximity_sensor'
+    }
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }


### PR DESCRIPTION
Android Gradle Plugin 8 requires all projects to include a namespace, this adds that