### PR TITLE
Remove not needed body sensor permission

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -2,7 +2,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   package="dev.jeremyko.proximity_sensor">
    <uses-permission android:name="android.hardware.sensor.proximity"/>
-   <uses-permission android:name="android.permission.BODY_SENSORS_BACKGROUND"/>
    <uses-permission android:name="android.permission.ACTIVITY_RECOGNITION"/>
    <uses-permission android:name="android.permission.WAKE_LOCK"/>
 


### PR DESCRIPTION
Issue: [Body sensor permission causes the app to need to comply to Health app policies](https://github.com/jeremyko/flutter-proximity-sensor-plugin/issues/12)

This permission doesn't seem to be needed for the scope of this package