### PR TITLE
Remove not needed permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ This is an example.
 Regarding permissions, you may need the following settings in your `AndroidManifest.xml` file:
 
     <uses-permission android:name="android.hardware.sensor.proximity"/>
-    <uses-permission android:name="android.permission.BODY_SENSORS_BACKGROUND"/>
     <uses-permission android:name="android.permission.ACTIVITY_RECOGNITION"/>
     <uses-permission android:name="android.permission.WAKE_LOCK"/>
 

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -2,7 +2,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   package="dev.jeremyko.proximity_sensor">
    <uses-permission android:name="android.hardware.sensor.proximity"/>
-   <uses-permission android:name="android.permission.BODY_SENSORS_BACKGROUND"/>
    <uses-permission android:name="android.permission.ACTIVITY_RECOGNITION"/>
    <uses-permission android:name="android.permission.WAKE_LOCK"/>
 

--- a/example/README.md
+++ b/example/README.md
@@ -30,7 +30,6 @@ This is an example.
 Regarding permissions, you may need the following settings in your `AndroidManifest.xml` file:
 
     <uses-permission android:name="android.hardware.sensor.proximity"/>
-    <uses-permission android:name="android.permission.BODY_SENSORS_BACKGROUND"/>
     <uses-permission android:name="android.permission.ACTIVITY_RECOGNITION"/>
 
 **Some recent devices use virtual proximity sensors. There are no physical sensors. I found it hard to trust the sensor information in this case.**


### PR DESCRIPTION
issue: [Requesting not needed body sensor permissions forces the app using this to comply to health policies](https://github.com/jeremyko/flutter-proximity-sensor-plugin/issues)

Fix: Remove `BODY_SENSORS_BACKGROUND` permission as it seems not needed for the scope of this package. (Android only)