### PR TITLE
build: Update `compileSdkVersion` and dependencies for Android project

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,14 +2,14 @@ group 'dev.jeremyko.proximity_sensor'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.8.22'
+    ext.kotlin_version = '2.2.20'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.1.0'
+        classpath 'com.android.tools.build:gradle:8.13.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -25,7 +25,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 36
     if (project.android.hasProperty('namespace')) {
         namespace 'dev.jeremyko.proximity_sensor'
     }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -45,7 +45,3 @@ android {
         jvmTarget = '17'
     }
 }
-
-dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-}

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Jan 25 12:09:51 EET 2023
+#Mon Sep 15 15:48:57 EEST 2025
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip


### PR DESCRIPTION
This pull request:
- sets the `compileSdkVersion` to 36 from 31;
- updates AGP and gradle versions to 8.13.0 and 8.14.3 respectively;
- updates Kotlin version to 2.2.20;
- removes the no longer necessary `kotlin-stdlib-jdk7` dependency.

The reason for change: newer Flutter SDKs and Android libraries require compiling against a more recent Android SDK, and release builds using this plugin will fail with the following message (error log truncated):

```txt
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':proximity_sensor:checkReleaseAarMetadata'.
> A failure occurred while executing com.android.build.gradle.internal.tasks.CheckAarMetadataWorkAction
   > 19 issues were found when checking AAR metadata:

       1.  Dependency 'androidx.fragment:fragment:1.7.1' requires libraries and applications that
           depend on it to compile against version 34 or later of the
           Android APIs.

           :proximity_sensor is currently compiled against android-31.

           Recommended action: Update this project to use a newer compileSdk
           of at least 34, for example 36.

           Note that updating a library or application's compileSdk (which
           allows newer APIs to be used) can be done separately from updating
           targetSdk (which opts the app in to new runtime behavior) and
           minSdk (which determines which devices the app can be installed
           on).

       2.  Dependency 'androidx.window:window:1.2.0' requires libraries and applications that
           depend on it to compile against version 34 or later of the
           Android APIs.

           :proximity_sensor is currently compiled against android-31.

           Recommended action: Update this project to use a newer compileSdk
           of at least 34, for example 36.

           Note that updating a library or application's compileSdk (which
           allows newer APIs to be used) can be done separately from updating
           targetSdk (which opts the app in to new runtime behavior) and
           minSdk (which determines which devices the app can be installed
           on).
```