### PR TITLE
fix: correct NotificationCenter observer removal in Swift to prevent memory leak

### DIFF
--- a/ios/Classes/SwiftProximitySensorPlugin.swift
+++ b/ios/Classes/SwiftProximitySensorPlugin.swift
@@ -6,6 +6,7 @@ public class SwiftProximityStreamHandler : NSObject,FlutterStreamHandler
 {
     let notiCenter = NotificationCenter.default
     let device =  UIDevice.current
+    private var proximityObserver: NSObjectProtocol?
     
     public func onListen(withArguments arguments: Any?,
                          eventSink events: @escaping FlutterEventSink) -> FlutterError? {
@@ -21,7 +22,7 @@ public class SwiftProximityStreamHandler : NSObject,FlutterStreamHandler
         }
 
         //sensor is available
-        notiCenter.addObserver(forName: UIDevice.proximityStateDidChangeNotification,
+        proximityObserver = notiCenter.addObserver(forName: UIDevice.proximityStateDidChangeNotification,
                                 object: device,
                                 queue: nil,
                                 using : { (notification) in
@@ -35,7 +36,10 @@ public class SwiftProximityStreamHandler : NSObject,FlutterStreamHandler
     }
     
     public func onCancel(withArguments arguments: Any?) -> FlutterError? {
-        notiCenter.removeObserver(self)
+        if let observer = proximityObserver {
+            notiCenter.removeObserver(observer)
+            proximityObserver = nil
+        }
         device.isProximityMonitoringEnabled = false
         
         return nil


### PR DESCRIPTION
### Description
This PR fixes a memory leak in the Swift implementation of the proximity sensor plugin.

### The Problem
The `SwiftProximityStreamHandler` was using `NotificationCenter.default.addObserver(forName:object:queue:using:)` to listen for proximity state changes. This method returns an opaque observer object (token) that must be passed to `removeObserver(_:)` to unregister. 

Previously, `onCancel` was calling `notiCenter.removeObserver(self)`, which is ineffective for block-based observers. This led to observers accumulating in memory every time the stream was stopped and started.

### The Solution
- Added a `proximityObserver` property to `SwiftProximityStreamHandler` to store the `NSObjectProtocol` token.
- Updated `onListen` to capture the token returned by `addObserver`.
- Updated `onCancel` to properly remove the observer using the stored token and then nil it out.
